### PR TITLE
Fix support for descendant selectors.

### DIFF
--- a/src/ready.js
+++ b/src/ready.js
@@ -64,10 +64,11 @@ function matches(el, selector) {
 function checkMutations(mutations) {
     for (const mutation of mutations) {
         for (const element of mutation.addedNodes) {
+            if (element.nodeType !== 1) continue;
             listeners.forEach((listener) => {
-                if (element.nodeType === 1 && matches(element, listener.selector)) {
-                    listener.callback.call(element, element);
-                }
+                const items = Array.from(element.querySelectorAll(listener.selector));
+                if (matches(element, listener.selector)) items.push(element);
+                items.forEach((el) => listener.callback.call(el, el));
             });
         }
     }

--- a/test/specs/ready.js
+++ b/test/specs/ready.js
@@ -79,6 +79,54 @@ describe('ready', () => {
         requestAnimationFrame(() => document.body.appendChild(frag));
     });
 
+    it('should invoke the callback for descendant element that matches the selector', (done) => {
+        const child = document.createElement('div');
+        child.className = 'kid';
+
+        const element = document.createElement('div');
+        element.className = 'bar';
+        element.appendChild(child);
+
+        const spy = sinon.spy((added) => {
+            expect(spy.calledOnce).to.equal(true);
+            expect(added).to.equal(child);
+            expect(document.body.contains(added)).to.equal(true);
+            expect(spy.calledOn(added)).to.equal(true);
+
+            document.body.removeChild(element);
+            off();
+            done();
+        });
+
+        const off = ready('.kid', spy);
+
+        requestAnimationFrame(() => document.body.appendChild(element));
+    });
+
+    it('should invoke the callback for descendant element that matches complex selector', (done) => {
+        const child = document.createElement('div');
+        child.className = 'kid';
+
+        const element = document.createElement('div');
+        element.className = 'bar';
+        element.appendChild(child);
+
+        const spy = sinon.spy((added) => {
+            expect(spy.calledOnce).to.equal(true);
+            expect(added).to.equal(child);
+            expect(document.body.contains(added)).to.equal(true);
+            expect(spy.calledOn(added)).to.equal(true);
+
+            document.body.removeChild(element);
+            off();
+            done();
+        });
+
+        const off = ready('.bar > .kid', spy);
+
+        requestAnimationFrame(() => document.body.appendChild(element));
+    });
+
     it('should return a function that stops observing for new elements when invoked', (done) => {
         const element = document.createElement('div');
         element.className = 'bar';


### PR DESCRIPTION
Fixes a regression in v1.3.0 where descendant selectors were possible because all listener selectors where always checked against the document using `document.querySelectorAll()` irrespective of the type of mutation and whether the nodes were added or removed.

After the change to consult `MutationRecord.addedNodes` only the top-level node of whole added subtrees are checked, and use of `Element.matches()` restricts to those elements that match `listener.selector` and all children in the subtree are now ignored. Again in the past this worked because the selector was queried from the document.

The fix is to take the element if it matches, but also add all those elements that are descendants by using `element.querySelectorAll()`. This should solve most situations that were previously supported, but not where the added node is not an ancestor of the selector provided.

In addition, the check for `nodeType` has been moved ahead of looping over the listeners to avoid unnecessary cycles for other node types.

~~I'm sorry - I haven't added a test for this as I'm not familiar with the testing tools that you use. Something that basically checks `ready('.aaa > .bbb', () => {...})` works with `<div class="aaa"><div class="bbb"></div></div>` should be enough.~~